### PR TITLE
Corrige trigger de deploy: elimina condición 'pull_request.merged'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   deploy:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
       FRONT_DIR: frontend

--- a/.gitignore
+++ b/.gitignore
@@ -154,5 +154,6 @@ psd
 thumb
 sketch
 *.env
+*.env.*
 *.mp4
 # End of https://www.toptal.com/developers/gitignore/api/react,node


### PR DESCRIPTION
- Elimina condición 'if: github.event.pull_request.merged == true'
- Workflow ahora se ejecuta correctamente al hacer push a la rama 'deploy'
- Permite despliegue automático al fusionar PR desde main a deploy